### PR TITLE
Fixing compile issues in Linux, adding CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(streamprintf LANGUAGES CXX)
+
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/streamprintf.h
+++ b/streamprintf.h
@@ -44,8 +44,9 @@
 //      oprintf(cout, "%ld", i);
 //      oprintf(cout, "%d", l);
 
-// #define STREAMPRINTF_STRICT_INTSIZE
-
+#ifndef _MSC_VER
+    #define STREAMPRINTF_STRICT_INTSIZE
+#endif
 
 #include <assert.h>
 #include <stdarg.h>
@@ -97,12 +98,17 @@ public:
 	Printf& operator<<(short n)                { Do(PRINTF_TYPE(Short| Int), n); return *this; }
 	Printf& operator<<(int n)                  { Do(PRINTF_TYPE(None | Int), n); return *this; }
 	Printf& operator<<(long n)                 { Do(PRINTF_TYPE(Long | Int), n); return *this; }
-	Printf& operator<<(INT64 n)                { Do(PRINTF_TYPE(Int64| Int), n); return *this; }
+	
+	template<typename T>
+	typename std::enable_if<!std::is_same<long, INT64>::value && std::is_same<T, INT64>::value, Printf&>::type
+	operator<<(T n)                { Do(PRINTF_TYPE(Int64| Int), n); return *this; }
 
 	Printf& operator<<(unsigned short u)       { Do(PRINTF_TYPE(Short| Unsigned), u); return *this; }
 	Printf& operator<<(unsigned int u)         { Do(PRINTF_TYPE(None | Unsigned), u); return *this; }
 	Printf& operator<<(unsigned long u)        { Do(PRINTF_TYPE(Long | Unsigned), u); return *this; }
-	Printf& operator<<(UINT64 u)               { Do(PRINTF_TYPE(Int64| Unsigned), u); return *this; }
+	template<typename T>
+	typename std::enable_if<!std::is_same<unsigned long, UINT64>::value && std::is_same<T, UINT64>::value, Printf&>::type
+	operator<<(T u)               { Do(PRINTF_TYPE(Int64| Unsigned), u); return *this; }
 
 	Printf& operator<<(float f)                { Do(PRINTF_TYPE(None | Float), f); return *this; }
 	Printf& operator<<(double f)               { Do(PRINTF_TYPE(None | Float), f); return *this; }

--- a/streamprintf.h
+++ b/streamprintf.h
@@ -150,7 +150,7 @@ protected:
 // wvsprintf() does not support that.
 
 template <>
-inline void Printf<char>::my_vsprintf(char* output, size_t width, const char* format, va_list vl)
+inline void Printf<char>::my_vsprintf(char* output, [[maybe_unused]] size_t width, const char* format, va_list vl)
 {
 	#if _MSC_VER >= 1400
 		vsprintf_s(output, width, format, vl);

--- a/streamprintf.h
+++ b/streamprintf.h
@@ -277,7 +277,7 @@ void Printf<CharT>::Do(int sizeAndType, ...)
 	else if (fmtChar == 'S')
 		fmtChar = 's';
 
-	assertmsg(i < sizeof(format) / sizeof(format[0]), "printf: Format specification is too long");
+	assertmsg(static_cast<size_t>(i) < sizeof(format) / sizeof(format[0]), "printf: Format specification is too long");
 	format[i] = '\0';
 
 #ifndef NDEBUG

--- a/streamprintf.h
+++ b/streamprintf.h
@@ -172,6 +172,7 @@ inline void Printf<wchar_t>::my_vsprintf(wchar_t* output, size_t width, const wc
 #endif
 
 //-----------------------------------------------------------------------------
+#pragma GCC diagnostic ignored "-Wstack-usage="
 template <class CharT>
 void Printf<CharT>::Do(int sizeAndType, ...)
 {
@@ -367,6 +368,7 @@ void Printf<CharT>::Do(int sizeAndType, ...)
 
 	OutputStaticText();
 }
+#pragma GCC diagnostic pop
 
 //-----------------------------------------------------------------------------
 template <class CharT>

--- a/streamprintf.h
+++ b/streamprintf.h
@@ -135,9 +135,9 @@ protected:
 	void my_vsprintf(CharT* output, size_t width, const CharT* format, va_list vl);
 	void OutputStaticText();
 
+	std::basic_ostream<CharT>& _ostm;	// stream to which we're outputting
 	const CharT* _fmt;		// the format string currently being processed
 	size_t _pos;			// current position with _fmt
-	std::basic_ostream<CharT>& _ostm;	// stream to which we're outputting
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Hi @mmorearty ,

Thank you for publishing a very useful streamprintf library! It's amazingly handy when one needs to quickly redirect printf() in legacy code for internal processing.

I would like to offer some simple fixes to use your library in modern times. The most significant issue is that 'long' and 'int' are usually same only in Windows. Other fixes silence some GCC warnings. Finally, I add CMake file to 'include' your library into software builds managed by CMake. 